### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -553,3 +553,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Large Files
+*.dzi
+*.svs


### PR DESCRIPTION
ensure we do not push any additional .dzi files. brady ones are fine but a massive one will bloat the repo and suck